### PR TITLE
ESX-LISA 2.1.0 Release

### DIFF
--- a/OSAbstractions.ps1
+++ b/OSAbstractions.ps1
@@ -21,6 +21,8 @@
 ## v1.0 - xiaofwan - 11/25/2016 - Fork from github.com/LIS/lis-test.
 ##                                Incorporate VMware PowerCLI with framework
 ## v1.1 - xiaofwan - 2/3/2017 - $True will be $true and $False will be $false.
+## v1.2 - xiaofwan - 2/21/2017 - Two new functions to fetch kernel and firmware
+##                               version info.
 ##
 ###############################################################################
 
@@ -249,6 +251,56 @@ function GetOSType ([System.Xml.XmlElement] $vm)
     }
 
     return $os
+}
+
+#####################################################################
+#
+# GetKernelVersion()
+#
+#####################################################################
+function GetKernelVersion ()
+{
+	<#
+	.Synopsis
+    	Ask the OS to provide Kernel version.
+    .Description
+        Use SSH to send a uname command to the VM.  Use the
+        returned name as Kernel version.
+	#>
+
+    # plink will pending at waiting password if sshkey failed auth, so
+    # pipe a 'y' to response
+    $ver = echo y | bin\plink -i ssh\${sshKey} root@${hostname} "uname -r"
+
+    return $ver
+}
+
+
+#####################################################################
+#
+# GetFirmwareVersion()
+#
+#####################################################################
+function GetFirmwareVersion ()
+{
+	<#
+	.Synopsis
+    	Ask the OS to provide firmware version.
+    .Description
+        Use SSH to send a uname command to the VM.  The firmware is 
+        based on shell command result.
+	#>
+
+    # plink will pending at waiting password if sshkey failed auth, so
+    # pipe a 'y' to response
+    $cmdResult = echo y | bin\plink -i ssh\${sshKey} root@${hostname} "ls /sys/firmware/efi"
+
+    $firmware = "BIOS"
+    if ($cmdResult -eq 0)
+    {
+        $firmware = "EFI"
+    }
+    return $firmware
 }
 
 

--- a/stateEngine.ps1
+++ b/stateEngine.ps1
@@ -35,6 +35,7 @@
 ## v1.9 - xiaofwan - 2/21/2017 - ESX host version, kernel and firmware version
 ##                               are visable in XML result.
 ## v2.0 - xiaofwan - 2/21/2017 - Iteration related code has been removed.
+## v2.1 - xiaofwan - 2/21/2017 - Add test case running date and time in XML.
 ##
 ###############################################################################
 
@@ -339,8 +340,9 @@ function RunICTests([XML] $xmlConfig)
         $vm.AppendChild($newElement);
 
         #
-        # Add test suite into test result XML
+        # Add test suite and test date time into test result XML
         #
+        SetTimeStamp $testStartTime.toString()
         SetResultSuite $vm.suite
 
         #

--- a/stateEngine.ps1
+++ b/stateEngine.ps1
@@ -32,6 +32,8 @@
 ## v1.6 - xiaofwan - 2/3/2017 - Add test case running time support.
 ## v1.7 - xiaofwan - 2/3/2017 - $True will be $true and $False will be $false.
 ## v1.8 - xiaofwan - 2/4/2017 - Test result can be exported as JUnix XML file.
+## v1.9 - xiaofwan - 2/21/2017 - ESX host version, kernel and firmware version
+##                               are visable in XML result.
 ##
 ###############################################################################
 
@@ -343,7 +345,7 @@ function RunICTests([XML] $xmlConfig)
         #
         # Add test suite into test result XML
         #
-        SetResultSuite $vm.suite $testResult
+        SetResultSuite $vm.suite
 
         #
         # Add some information to the email summary text
@@ -353,7 +355,7 @@ function RunICTests([XML] $xmlConfig)
         $outGetCliVer = Get-PowerCLIVersion
         $vm.emailSummary += "    PowerCLI :  $($outGetCliVer.UserFriendlyVersion) <br />"
         $outGlobalVar = $global:DefaultVIServer
-        $vm.emailSummary += "    vCenter :  version $($outGlobalVar.Version) build $($outGlobalVar.Build) <br />"
+        $vm.emailSummary += "    vCenter :  version $($outGlobalVar.Version) build $($outGlobalVar.Build) <br />" 
         #
         # Verify the ESXi serer is on and connected.
         #
@@ -371,6 +373,11 @@ function RunICTests([XML] $xmlConfig)
         $vm.emailSummary += "    Suite : running at ESXi host $($vm.hvServer) <br />"
         $vm.emailSummary += "    Host : $($vm.hvServer) with ESXi $($vmhostOut.Version) build $($vmhostOut.Build)<br />"
         $vm.emailSummary += "<br /><br />"
+
+        #
+        # Add ESX host version into result XML
+        #
+        SetESXVersion "$($vmhostOut.Version) build $($vmhostOut.Build)"
 
         #
         # Make sure the VM actually exists
@@ -1590,6 +1597,13 @@ function DoSystemUp([System.Xml.XmlElement] $vm, [XML] $xmlData)
     #
     $os = (GetOSType $vm).ToString()
     LogMsg 9 "INFO : The OS type is $os"
+
+    #
+    # Add guest kernel version and firmware info int result XML
+    #
+    $kernelVer = GetKernelVersion
+    $firmwareVer = GetFirmwareVersion
+    SetOSInfo $kernelVer $firmwareVer
 
     UpdateState $vm $PushTestFiles
 

--- a/stateEngine.ps1
+++ b/stateEngine.ps1
@@ -36,6 +36,8 @@
 ##                               are visable in XML result.
 ## v2.0 - xiaofwan - 2/21/2017 - Iteration related code has been removed.
 ## v2.1 - xiaofwan - 2/21/2017 - Add test case running date and time in XML.
+## v2.2 - xiaofwan - 2/21/2017 - Add SetRunningTime in ForceShutDown to support 
+##                               time calculation in force shut down scenario.
 ##
 ###############################################################################
 
@@ -2628,11 +2630,7 @@ function DoDetermineReboot([System.Xml.XmlElement] $vm, [XML] $xmlData)
             }
             else
             {
-                $caseEndTime = [DateTime]::Now
-                $deltaTime = $caseEndTime - [DateTime]::Parse($vm.caseStartTime)
-                LogMsg 0 "Info : $($vm.vmName) currentTest lasts $($deltaTime.hours) Hours, $($deltaTime.minutes) Minutes, $($deltaTime.seconds) seconds."
-
-                SetRunningTime $vm.currentTest $deltaTime.TotalMinutes
+                SetRunningTime $vm.currentTest $vm
 
                 #
                 # Mark next test not rebooted
@@ -2773,11 +2771,7 @@ function DoShuttingDown([System.Xml.XmlElement] $vm, [XML] $xmlData)
         }
         else
         {
-            $caseEndTime = [DateTime]::Now
-            $deltaTime = $caseEndTime - [DateTime]::Parse($vm.caseStartTime)
-            LogMsg 0 "Info : $($vm.vmName) currentTest lasts $($deltaTime.hours) Hours, $($deltaTime.minutes) Minutes, $($deltaTime.seconds) seconds."
-            
-            SetRunningTime $vm.currentTest $deltaTime.TotalMinutes
+            SetRunningTime $vm.currentTest $vm
 
             UpdateState $vm $SystemDown
         }
@@ -2882,11 +2876,7 @@ function DoRunCleanUpScript([System.Xml.XmlElement] $vm, [XML] $xmlData)
         LogMsg 0 "Error : $($vm.vmName) entered RunCleanupScript state when test $($vm.currentTest) does not have a cleanup script"
         $vm.emailSummary += "Entered RunCleanupScript but test does not have a cleanup script<br />"
     }
-    $caseEndTime = [DateTime]::Now
-    $deltaTime = $caseEndTime - [DateTime]::Parse($vm.caseStartTime)
-    LogMsg 0 "Info : $($vm.vmName) currentTest lasts $($deltaTime.hours) Hours, $($deltaTime.minutes) Minutes, $($deltaTime.seconds) seconds."
-    
-    SetRunningTime $vm.currentTest $deltaTime.TotalMinutes
+    SetRunningTime $vm.currentTest $vm
 
     UpdateState $vm $SystemDown
 }
@@ -2953,6 +2943,8 @@ function DoForceShutDown([System.Xml.XmlElement] $vm, [XML] $xmlData)
 
     if ($v.PowerState -eq "PoweredOff")
     {
+        SetRunningTime $vm.currentTest $vm
+        
         UpdateState $vm $nextState
     }
     else
@@ -2982,6 +2974,8 @@ function DoForceShutDown([System.Xml.XmlElement] $vm, [XML] $xmlData)
 
             if ($v.PowerState -eq "PoweredOff")
             {
+                SetRunningTime $vm.currentTest $vm
+
                 UpdateState $vm $nextState
                 break
             }

--- a/utilFunctions.ps1
+++ b/utilFunctions.ps1
@@ -36,6 +36,8 @@
 ##                               firmware and ESX version.
 ## v1.9 - xiaofwan - 2/21/2017 - Iteration related code has been removed.
 ## v2.0 - xiaofwan - 2/21/2017 - Add test case running date and time in XML.
+## v2.1 - xiaofwan - 2/21/2017 - Move case running time calculation into 
+##                               SetRunningTime function.
 ##
 ###############################################################################
 
@@ -414,7 +416,7 @@ function SetTestResult([String] $testName, [String] $testID, [String] $completio
 # SetRunningTime
 #
 #####################################################################
-function SetRunningTime([String] $testName, [String] $runningTime)
+function SetRunningTime([String] $testName, [System.Xml.XmlElement] $vm)
 {
     <#
     .Synopsis
@@ -427,15 +429,20 @@ function SetRunningTime([String] $testName, [String] $runningTime)
         The test name
         Type : [String]
     
-    .Parameter runningTime
-        The duration of test running
-        Type : [String]
+   .Parameter vm
+        An XML element representing the VM
+        Type : [System.Xml.XmlElement]
 
     .Example
-        SetRunningTime $testName $runningTime
+        SetRunningTime $testName $vm
     #>
-    LogMsg 6 ("Info :    SetRunningTime($runningTime)")
-    $runningTime = "{0:N2}" -f [float]$runningTime
+    LogMsg 6 ("Info :    SetRunningTime($testName)")
+
+    $caseEndTime = [DateTime]::Now
+    $deltaTime = $caseEndTime - [DateTime]::Parse($vm.caseStartTime)
+    LogMsg 0 "Info : $($vm.vmName) currentTest lasts $($deltaTime.hours) Hours, $($deltaTime.minutes) Minutes, $($deltaTime.seconds) seconds."
+    
+    $runningTime = "{0:N2}" -f $deltaTime.TotalMinutes
 
     foreach ($testCase in $testResult.testsuite.testcase)
     {

--- a/utilFunctions.ps1
+++ b/utilFunctions.ps1
@@ -32,6 +32,8 @@
 ## v1.6 - xiaofwan - 2/4/2017 - Remove Test-Admin function.
 ## v1.7 - xiaofwan - 2/6/2017 - The <skipped/> section should be removed when
 ##                              case failed or aborted.
+## v1.8 - xiaofwan - 2/21/2017 - Two new functions to set XML result the kernel
+##                               firmware and ESX version.
 ##
 ###############################################################################
 
@@ -195,6 +197,11 @@ function GetJUnitXML()
 
     $template = @'
 <testsuite name="">
+<properties>
+    <property name="esx.version" value="" />
+    <property name="kernel.version" value="" />
+    <property name="firmware.version" value="" />
+</properties>
 <testcase id="" name="" time="">
     <skipped/>
     <failure type=""></failure>
@@ -213,6 +220,81 @@ function GetJUnitXML()
     Remove-Item $templatePath
 
     return $junit_xml
+}
+
+#####################################################################
+#
+# SetESXVersion
+#
+#####################################################################
+function SetESXVersion([String] $ver)
+{
+    <#
+    .Synopsis
+        Add ESX version into XML result.
+
+    .Description
+        Find the ESX version property and set ESX version into result XML object.
+
+    .Parameter ver
+        The version of ESX host.
+        Type : [String]
+
+    .Example
+        SetESXVersion "6.0 build 4192238"
+    #>
+    LogMsg 6 ("Info :    SetESXVersion($($ver))")
+
+    foreach ($property in $testResult.testsuite.properties.property)
+    {
+        if ($property.name -eq "esx.version")
+        {
+            $property.value = $ver
+            return
+        }
+    }
+}
+
+#####################################################################
+#
+# SetOSInfo
+#
+#####################################################################
+function SetOSInfo([String] $kernelVer, [String] $firmwareVer)
+{
+    <#
+    .Synopsis
+        Add Kernel and firmware version into XML result.
+
+    .Description
+        Find the Kernel and firmware version properties and set Kernel
+        and firmware version into result XML object.
+
+    .Parameter kernelVer
+        The version of guest kernel.
+        Type : [String]
+
+    .Parameter firmwareVer
+        The version of guest firmware info.
+        Type : [String]
+
+    .Example
+        SetOSInfo "2.6.32-694.el6.x86_64" "BIOS"
+    #>
+    LogMsg 6 ("Info :    SetOSInfo($($kernelVer), $($firmwareVer))")
+
+    foreach ($property in $testResult.testsuite.properties.property)
+    {
+        if ($property.name -eq "kernel.version" -and $property.value -eq "")
+        {
+            $property.value = $kernelVer
+        }
+        
+        if ($property.name -eq "firmware.version" -and $property.value -eq "")
+        {
+            $property.value = $firmwareVer
+        }
+    }
 }
 
 #####################################################################

--- a/utilFunctions.ps1
+++ b/utilFunctions.ps1
@@ -35,6 +35,7 @@
 ## v1.8 - xiaofwan - 2/21/2017 - Two new functions to set XML result the kernel
 ##                               firmware and ESX version.
 ## v1.9 - xiaofwan - 2/21/2017 - Iteration related code has been removed.
+## v2.0 - xiaofwan - 2/21/2017 - Add test case running date and time in XML.
 ##
 ###############################################################################
 
@@ -197,7 +198,7 @@ function GetJUnitXML()
     LogMsg 6 ("Info :    GetJUnitXML()")
 
     $template = @'
-<testsuite name="">
+<testsuite name="" timestamp="">
 <properties>
     <property name="esx.version" value="" />
     <property name="kernel.version" value="" />
@@ -322,6 +323,32 @@ function SetResultSuite([String] $testSuite)
     LogMsg 6 ("Info :    SetResultSuite($($testSuite))")
 
     $testResult.testsuite.name = $testSuite
+}
+
+#####################################################################
+#
+# SetTimeStamp
+#
+#####################################################################
+function SetTimeStamp([String] $testTimeStamp)
+{
+    <#
+    .Synopsis
+        Add test date time in result XML object.
+
+    .Description
+        Find the test suite, and configure test date time into result XML object.
+
+    .Parameter testTimeStamp
+        The start time of test run
+        Type : [String]
+
+    .Example
+        SetTimeStamp "02/21/2017 13:14:25"
+    #>
+    LogMsg 6 ("Info :    SetTimeStamp($($testTimeStamp))")
+
+    $testResult.testsuite.timestamp = $testTimeStamp
 }
 
 #####################################################################


### PR DESCRIPTION
ESX-LISA 2.1 is a minor release, which does not need any case code change.
##New
1. ESX host version, kernel and firmware version are visible in XML result.
2. add test runing date in result XML

##Improved
1. remove iteration feature and related code

##Fixed
1. resolve an issue the running time cannot be calculated when case exited at ForceShutdown status.