### PR TITLE
optimized caes testscripts/ovt_check_suspend_timesync.ps1, make sure …

### DIFF
--- a/testscripts/ovt_check_suspend_timesync.ps1
+++ b/testscripts/ovt_check_suspend_timesync.ps1
@@ -153,7 +153,7 @@ Write-Output "DONE. VM Power state is $state"
 #
 # Enable timesync
 #
-$enable = bin\plink.exe -i ssh\${sshKey} root@${ipv4} "vmware-toolbox-cmd timesync enable"
+$enable = bin\plink.exe -i ssh\${sshKey} root@${ipv4} "systemctl restart vmtoolsd && vmware-toolbox-cmd timesync enable"
 if ($enable -ne "Enabled")
 {
     Write-Error -Message "timesync enable failed" -Category ObjectNotFound -ErrorAction SilentlyContinue


### PR DESCRIPTION
…the time in host and guest same before suspend.